### PR TITLE
A few bug fixes more

### DIFF
--- a/src/core/actions/cityactions/GrowForest.java
+++ b/src/core/actions/cityactions/GrowForest.java
@@ -35,7 +35,9 @@ public class GrowForest extends CityAction
     @Override
     public boolean execute(GameState gs) {
         if (isFeasible(gs)){
-            gs.getBoard().setTerrainAt(targetPos.x, targetPos.y, Types.TERRAIN.FOREST);
+            Board b = gs.getBoard();
+            b.setTerrainAt(targetPos.x, targetPos.y, Types.TERRAIN.FOREST);
+            b.setResourceAt(targetPos.x, targetPos.y, null);
             gs.getTribe(this.cityId).subtractStars(TribesConfig.GROW_FOREST_COST);
             return true;
         }

--- a/src/core/actors/City.java
+++ b/src/core/actors/City.java
@@ -111,7 +111,7 @@ public class City extends Actor{
         Tribe tribe = gameState.getTribe(this.tribeId);
 
         //Population added by the base building.
-        if(isBase && isPopulation && !onlyMatching) addPopulation(building.getBonus());
+        if(isBase && isPopulation && !onlyMatching) addPopulation(multiplier * building.getBonus());
 
         //Check all buildings next to the new building position.
         for(Vector2d adjPosition : building.position.neighborhood(1, 0, board.getSize()))
@@ -126,11 +126,11 @@ public class City extends Actor{
                 if(cityId == actorId)
                 {
                     //the matching building belongs to this city
-                    existingBuilding = this.getBuilding(building.position.x, building.position.y);
+                    existingBuilding = this.getBuilding(adjPosition.x, adjPosition.y);
                 }else if(tribe.getCitiesID().contains(cityId)) {
                     //the matching building belongs to a city from a different tribe
                     City city = (City) gameState.getActor(cityId);
-                    existingBuilding = city.getBuilding(building.position.x, building.position.y);
+                    existingBuilding = city.getBuilding(adjPosition.x, adjPosition.y);
                     cityToAddTo = city;
 
                 }else return; //This may happen if the building belongs to a city from another tribe.

--- a/src/utils/GameView.java
+++ b/src/utils/GameView.java
@@ -15,6 +15,7 @@ import core.actions.unitactions.Examine;
 import core.actors.Actor;
 import core.actors.City;
 import core.actors.Tribe;
+import core.actors.units.Catapult;
 import core.actors.units.SuperUnit;
 import core.actors.units.Unit;
 import core.game.Board;
@@ -151,7 +152,7 @@ public class GameView extends JComponent {
                 if (u != null) {
 
                     int imgSize = (int) (CELL_SIZE * 0.75);
-                    if (u instanceof SuperUnit) imgSize = CELL_SIZE;
+                    if (u instanceof SuperUnit || u instanceof Catapult) imgSize = CELL_SIZE;
                     String imgFile = u.getType().getImageFile();
 
                     Point2D rotated = rotatePoint(j, i);

--- a/src/utils/InfoView.java
+++ b/src/utils/InfoView.java
@@ -82,7 +82,7 @@ public class InfoView extends JComponent {
         actionD.addActionListener(listenerD);
         actionD.setVisible(false);
         actionGF = new JButton("Grow");  // If plain
-        listenerGF = new CityActionListener("Grow");
+        listenerGF = new CityActionListener("GrowForest");
         actionGF.addActionListener(listenerGF);
         actionGF.setVisible(false);
         actionRG = new JButton("Gather");  // If resource


### PR DESCRIPTION
Growing a forest must destroy any resources on that tile
Correct matching building position being used for bonuses.
Also correct multiplier used for adding population (missing for removing buildings).
Updated cell size for Catapult display.
Corrected listener name for growing forests