### PR TITLE
GUI Updates

### DIFF
--- a/src/core/Constants.java
+++ b/src/core/Constants.java
@@ -3,6 +3,7 @@ package core;
 public class Constants {
     public static boolean VERBOSE = true;
     public static boolean VISUALS = true;
+    public static boolean DISABLE_NON_HUMAN_GRID_HIGHLIGHT = false;  // If true, human observing/playing can't highlight units of non-human players
     public static int FRAME_DELAY = 1000; //100;
     public static long TURN_TIME_MILLIS = 10000000; //10000; //10 seconds.
     public static int GUI_INFO_DELAY = 250;

--- a/src/core/Constants.java
+++ b/src/core/Constants.java
@@ -3,7 +3,7 @@ package core;
 public class Constants {
     public static boolean VERBOSE = true;
     public static boolean VISUALS = true;
-    public static int FRAME_DELAY = 2000; //100;
+    public static int FRAME_DELAY = 1000; //100;
     public static long TURN_TIME_MILLIS = 10000000; //10000; //10 seconds.
     public static int GUI_INFO_DELAY = 250;
 

--- a/src/utils/GUI.java
+++ b/src/utils/GUI.java
@@ -485,7 +485,6 @@ public class GUI extends JFrame {
         repaint();
     }
 
-
     public static Vector2d getActionPosition(GameState gs, Action a) {
         Vector2d pos = null;
         if (a instanceof Move) {
@@ -493,7 +492,7 @@ public class GUI extends JFrame {
         } else if (a instanceof Attack) {
             Unit target = (Unit) gs.getActor(((Attack) a).getTargetId());
             pos = target.getPosition();
-        } else if (a instanceof Recover || a instanceof HealOthers || a instanceof Disband) {
+        } else if (a instanceof Recover) {
             Unit u = (Unit) gs.getActor(((UnitAction) a).getUnitId());
             pos = u.getPosition();
         } else if (a instanceof Capture || a instanceof Convert || a instanceof Examine) {

--- a/src/utils/TechView.java
+++ b/src/utils/TechView.java
@@ -17,13 +17,13 @@ public class TechView extends JComponent {
 
     private Dimension size;
     JButton[] techs;
-    String[] techEffects;
     private GameState gs;
     ActionController ac;
     TechnologyNode[] technologies;
     ArrayList<TechnologyNode> roots, leaves;
     InfoView infoView;
 
+    // TODO: search functionality (i.e. "custom house -> Trade research")
     TechView(ActionController ac, InfoView infoView)
     {
         this.setLayout(new FlowLayout());


### PR DESCRIPTION
- Play/Resume, Play Turn (one player action then pause), Play Tick (all players actions then pause) buttons
- On-map action view during non-human play disabled + some todos
- Fixing issue #233 and avoiding action display overlap by moving Disband, HealOthers and Upgrade off-map onto side panel as buttons (Recover remains the only action at unit's location on-map).